### PR TITLE
chore: suppress ManualArrayCopy code replacement on format

### DIFF
--- a/src/main/java/h02/OneDimensionalArrayStuff.java
+++ b/src/main/java/h02/OneDimensionalArrayStuff.java
@@ -21,6 +21,7 @@ public class OneDimensionalArrayStuff {
      * @param value the value to append
      * @return a new array that is a copy of the input array with the given value appended at the end
      */
+    @SuppressWarnings("ManualArrayCopy")
     @StudentImplementationRequired("H2.1.1")
     public static int[] push(final int[] array, final int value) {
         // TODO: H2.1.1


### PR DESCRIPTION
IntelliJ currently auto replaces manual array copies with a system array copy on format. To prevent mistakes due to code formatting the warning should be suppressed.